### PR TITLE
Remove syndesis.version, rely on parent version.

### DIFF
--- a/syndesis-library-jdbc-driver/pom.xml
+++ b/syndesis-library-jdbc-driver/pom.xml
@@ -42,9 +42,6 @@
 
         <!-- plugins -->
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-
-        <!-- dependencies -->
-        <syndesis.version>1.3-SNAPSHOT</syndesis.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Remove syndesis.version, rely on parent version.