### PR TITLE
Fix build to use syndesis 1.11.x and other issues

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -14,12 +14,12 @@ Fill the arguments required by the prompt procedure and you will finally have a 
 ```bash
 mvn clean install
 ```
-if you like to build the extensions against a particular Syndesis version please set the `syndesis.version` property accordingly in the `pom.xml` or provide the variable to maven build:
+if you like to build the extensions against a particular Syndesis version please set the `syndesis.version` property accordingly in the `pom.xml`:
 
  ```bash
- mvn clean install -Dsyndesis.version=1.8.13
+ mvn clean install
  ```
-**Note**: the `master` branch is aligned with `master` [syndesis repository](https://github.com/syndesisio/syndesis). You can use release branches (ie [`1.3.x`](./tree/1.3.x), [`1.8.x`]((./tree/1.8.x)), ...) if you need to build the extensions provided in this repository targeting an old syndesis version.
+**Note**: the `master` branch is aligned with latest 1.x branch of [syndesis repository](https://github.com/syndesisio/syndesis). You can use release branches (ie [`1.3.x`](./tree/1.3.x), [`1.8.x`]((./tree/1.8.x)), ...) if you need to build the extensions provided in this repository targeting an old syndesis version.
 
 ### Build with automatic Syndesis version detection:
 Another option is to use the `syndesisServerUrl` to pass the url of a running Syndesis instance and let maven figure the right version out for you:

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <description>A Collection of Extensions for Syndesis</description>
 
   <properties>
-    <syndesis.version>2.0-SNAPSHOT</syndesis.version>
+    <syndesis.version>1.11.0</syndesis.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/syndesis-extension-cache/pom.xml
+++ b/syndesis-extension-cache/pom.xml
@@ -59,12 +59,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/syndesis-extension-cache/src/main/java/io/syndesis/extension/cache/CacheAction.java
+++ b/syndesis-extension-cache/src/main/java/io/syndesis/extension/cache/CacheAction.java
@@ -14,7 +14,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.model.PipelineDefinition;
 import org.apache.camel.model.ProcessorDefinition;
 import org.apache.camel.spi.InterceptStrategy;
-import org.apache.camel.support.processor.DelegateAsyncProcessor;
+import org.apache.camel.processor.DelegateAsyncProcessor;
 import org.apache.camel.util.ObjectHelper;
 
 import io.syndesis.extension.api.Step;
@@ -60,7 +60,7 @@ public class CacheAction implements Step {
             int remaining = steps;
 
             @Override
-            public Processor wrapProcessorInInterceptors(CamelContext context, NamedNode definition, Processor target, Processor nextTarget) throws Exception {
+            public Processor wrapProcessorInInterceptors(CamelContext context, ProcessorDefinition<?> definition, Processor target, Processor nextTarget) throws Exception {
                 System.out.println("intercept pipeline " + definition.getId() + ", " + cahceStepId);
 
                 if (definition instanceof PipelineDefinition) {


### PR DESCRIPTION
- Fix code to be compatible to camel 2.32, which is the version in main
  syndesis branch
- Currently there is no 1.11 release of upstream, so temporarily use
  downstream version
- Setting syndesis.version on command line doesn't work when running maven
  repackage-extension plugin, should set in pom.xml